### PR TITLE
WIP: add Nexus 7 2013 LTE (lineageos)

### DIFF
--- a/flavors/lineageos/device-dirs.json
+++ b/flavors/lineageos/device-dirs.json
@@ -1,15 +1,15 @@
 {
   "device/asus/deb": {
-    "date": "2020-10-30T01:44:48+03:00",
+    "date": "2020-10-30T02:28:26+03:00",
     "deepClone": false,
     "deps": [
       "device/asus/flo"
     ],
     "fetchSubmodules": false,
     "leaveDotGit": false,
-    "path": "/nix/store/yap21i11vynacs7l5j7n2b5f0hhq713i-android_device_asus_deb",
-    "rev": "743c68e0addcfd36471ec8f1f00c403046a35b70",
-    "sha256": "1amgbwnr64bqjzvlzsbl3nr13hjii93m9bm0ldmfxyz6jrf0w1z1",
+    "path": "/nix/store/bhm68mx610ylsi9cs41brh3rnh43zcml-android_device_asus_deb",
+    "rev": "b17c78e544556a42aa2e62180f30e24d67285d7f",
+    "sha256": "03cw5jpshpaldqsmzsbgwan5cc78pci1vvdaiw98zvg37aw69qdh",
     "url": "https://github.com/newkozlukov/android_device_asus_deb"
   },
   "device/asus/flo": {

--- a/flavors/lineageos/device-dirs.json
+++ b/flavors/lineageos/device-dirs.json
@@ -1,16 +1,29 @@
 {
   "device/asus/deb": {
-      "date": "2020-10-25T23:24:29+03:00",
-      "deepClone": false,
-      "deps": [
-          "kernel/google/msm"
-      ],
-      "fetchSubmodules": false,
-      "leaveDotGit": false,
-      "path": "/nix/store/sz3p7wqcbv3l969k9kigz5a489vdzljp-android_device_asus_deb-25c5951",
-      "url": "https://github.com/LineageOS/android_device_asus_deb",
-      "rev": "25c59513a0ec447dbc6fdec94388e15eb3367606",
-      "sha256": "14qvlpv76dmr7jci1xpal5qp79ap6ily0cjmww4i7v8pmqbbq9jl"
+    "date": "2020-10-30T01:44:48+03:00",
+    "deepClone": false,
+    "deps": [
+      "device/asus/flo"
+    ],
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/yap21i11vynacs7l5j7n2b5f0hhq713i-android_device_asus_deb",
+    "rev": "743c68e0addcfd36471ec8f1f00c403046a35b70",
+    "sha256": "1amgbwnr64bqjzvlzsbl3nr13hjii93m9bm0ldmfxyz6jrf0w1z1",
+    "url": "https://github.com/newkozlukov/android_device_asus_deb"
+  },
+  "device/asus/flo": {
+    "date": "2020-10-26T01:36:47-04:00",
+    "deepClone": false,
+    "deps": [
+      "kernel/google/msm"
+    ],
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/2lshwx6q9wl7am7x5dqz8y0kyypdpgvd-android_device_asus_flo",
+    "rev": "f10c74f005e45395acee91b8323ebbaf5ff5d8cd",
+    "sha256": "13zqn6jd253g0lq3k2rr5h8fqf5hnv5xs1k16kmrhgxwgd0lczgv",
+    "url": "https://github.com/LineageOS/android_device_asus_flo"
   },
   "device/asus/I001D": {
     "date": "2020-07-24T18:00:39+02:00",
@@ -2335,15 +2348,15 @@
     "url": "https://github.com/LineageOS/android_kernel_google_marlin"
   },
   "kernel/google/msm": {
-      "date": "2020-10-25T23:24:29+03:00",
-      "deepClone": false,
-      "deps": [],
-      "fetchSubmodules": false,
-      "leaveDotGit": false,
-      "path": "/nix/store/579qyjnbf55sq5yq487a1dp3nilcd34b-android_kernel_google_msm-77157df",
-      "rev": "77157df7317f291dbf3b73cef651f918c391eb63",
-      "sha256": "1gh2jj1crsixh12lw7hvn33rq84hyxmaryhlzq98anm7832fa33q",
-      "url": "https://github.com/LineageOS/android_kernel_google_msm"
+    "date": "2020-10-25T02:45:30-04:00",
+    "deepClone": false,
+    "deps": [],
+    "fetchSubmodules": false,
+    "leaveDotGit": false,
+    "path": "/nix/store/kl1k8pjvrcai7dcig8ca7zk35q7d03wv-android_kernel_google_msm",
+    "rev": "77157df7317f291dbf3b73cef651f918c391eb63",
+    "sha256": "1gh2jj1crsixh12lw7hvn33rq84hyxmaryhlzq98anm7832fa33q",
+    "url": "https://github.com/LineageOS/android_kernel_google_msm"
   },
   "kernel/google/msm-4.9": {
     "date": "2020-08-12T18:32:16-04:00",

--- a/flavors/lineageos/device-dirs.json
+++ b/flavors/lineageos/device-dirs.json
@@ -1,4 +1,17 @@
 {
+  "device/asus/deb": {
+      "date": "2020-10-25T23:24:29+03:00",
+      "deepClone": false,
+      "deps": [
+          "kernel/google/msm"
+      ],
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/sz3p7wqcbv3l969k9kigz5a489vdzljp-android_device_asus_deb-25c5951",
+      "url": "https://github.com/LineageOS/android_device_asus_deb",
+      "rev": "25c59513a0ec447dbc6fdec94388e15eb3367606",
+      "sha256": "14qvlpv76dmr7jci1xpal5qp79ap6ily0cjmww4i7v8pmqbbq9jl"
+  },
   "device/asus/I001D": {
     "date": "2020-07-24T18:00:39+02:00",
     "deepClone": false,
@@ -2320,6 +2333,17 @@
     "rev": "64d054883d446cada37c0b5de109394d4d1b852c",
     "sha256": "0ckjha9k9zr9n5qdm5jfc985qwqj3is9ympfpr2xrlfp9kjcj9bp",
     "url": "https://github.com/LineageOS/android_kernel_google_marlin"
+  },
+  "kernel/google/msm": {
+      "date": "2020-10-25T23:24:29+03:00",
+      "deepClone": false,
+      "deps": [],
+      "fetchSubmodules": false,
+      "leaveDotGit": false,
+      "path": "/nix/store/579qyjnbf55sq5yq487a1dp3nilcd34b-android_kernel_google_msm-77157df",
+      "rev": "77157df7317f291dbf3b73cef651f918c391eb63",
+      "sha256": "1gh2jj1crsixh12lw7hvn33rq84hyxmaryhlzq98anm7832fa33q",
+      "url": "https://github.com/LineageOS/android_kernel_google_msm"
   },
   "kernel/google/msm-4.9": {
     "date": "2020-08-12T18:32:16-04:00",

--- a/flavors/lineageos/device-metadata.json
+++ b/flavors/lineageos/device-metadata.json
@@ -789,5 +789,12 @@
     "name": "Le Pro 3",
     "variant": "userdebug",
     "vendor": "leeco"
+  },
+  "deb": {
+      "branch": "lineage-17.1",
+      "lineage_recovery": true,
+      "name": "Nexus 7 2013 (LTE)",
+      "variant": "userdebug",
+      "vendor": "asus"
   }
 }

--- a/flavors/lineageos/vendor-dirs.json
+++ b/flavors/lineageos/vendor-dirs.json
@@ -1,12 +1,12 @@
 {
   "vendor/asus": {
-    "date": "2020-08-05T11:07:41+02:00",
+    "date": "2020-10-28T14:38:05-04:00",
     "deepClone": false,
     "fetchSubmodules": false,
     "leaveDotGit": false,
-    "path": "/nix/store/kf6baqjig8k1v7fa5g1fax9fps1l11jy-proprietary_vendor_asus",
-    "rev": "11d66dc46ae2c3eb73275b0a8243c30f84a39349",
-    "sha256": "0i56n46p15h15vw9pckyyc0im7d3pc494p9m4x0c2s71shh851yg",
+    "path": "/nix/store/8rgw1jxxl4bxqh6z3bydsm9ygiphswgh-proprietary_vendor_asus",
+    "rev": "7dfb3938bad57bcc07ebd2d7e19fd32f25e7390b",
+    "sha256": "1qslnp7r7ddnpnsdf2q0dljpfgiqlg1mjwkawpx32l9ffd14rc40",
     "url": "https://github.com/TheMuppets/proprietary_vendor_asus"
   },
   "vendor/bq": {


### PR DESCRIPTION
Add support for building `lineage_deb`

Build command
---

From README, it wasn't clear what `configuration` to pass to build
LineageOS for a specific device. I tried this, which triggered download
of a huge lot of stuff and then failed with "not a valid product:
`lineage_deb`":

```bash
nix-build \
    --arg configuration '{ device="deb"; flavor="lineageos"; }' \
        -A bootImg -o bootImg \
&& nix-build \
   --arg configuration '{ device="deb"; flavor="lineageos"; }' \
        -A ota -o ota
```

I'll be running this same command after each bullet in the next section

What I tried to change
---

- I assumed I'm supposed to manually modify `device-metadata.json` and
`device-dirs.json`.
- After I noticed `deviceMetadata.${config.device}.vendor` in
 `default.nix`,
  I added `deb` key to devicesMetadata, with `vendor` set to `asus`.
  I noticed this triggers fetching one more repo:
  https://github.com/TheMuppets/proprietary_vendor_asus

  I assume this is a sign that I did the right thing
- I added `device/asus/deb` key to deviceDirs with all copypasted values and
  `deps` referencing the new key `kernel/google/msm`.
- Added `kernel/google/msm` key to deviceDirs, because I found lineageos
  wiki to reference this repo: https://github.com/LineageOS/android_kernel_google_msm

  I used the latest `rev` in the repo
- I assumed that `sha256` in deviceDirs is what's computed by
  `nix-prefetch-url --unpack $github_download_zip_url`,
  so I added those for `google/kernel/msm` and `device/asus/deb`.
- I assumed that `path` in deviceDirs should be the content-addressed
  path to unpacked git revision of `android_device_asus_deb` and
  `android_kernel_google_msm` for device and kernel respectively,
  so (after a failed build) I ran
  ```bash
  fd kernel_google /nix/store
  fd asus_deb /nix/store
  ```
  and copied the found directory paths

At this point the Build Command still fails with

```
Which product would you like? [aosp_arm] lineage_deb
build/make/core/product_config.mk:223: error: Can not locate config
makefile for product "lineage_deb".
...
21:16:29 dumpvars failed with: exit status 1
** Not a valid product: lineage_deb
```
